### PR TITLE
Allow brackets to contain non-token syntax, and only tokenize innermost brackets

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function t(str, obj, lang){
   }
   lang = lang || _lang;
   if (t[lang]) str = t[lang][str] || str;
-  return str.replace(/\{([^}]+)\}/g, function(_, name){
+  return str.replace(/\{([^{}}]+)\}/g, function(_, name){
     var value = get(name, obj);
     return typeof value !== 'undefined' ? value : _;
   });

--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ exports.lang = function(code){
  */
 
 function get (path, obj) {
-  return new Function('_', 'return _.' + path)(obj);
+  try {
+    return new Function('_', 'return _.' + path)(obj);
+  } catch (e) {
+    return obj[path];
+  }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,11 @@ describe('t(str)', function(){
     t('"{string}",{number}', {string: '', number: 0}).should.eql('"",0');
   })
 
+  it('should only tokenize innermost brackets', function() {
+    t('Hello {name}: function () { console.log("Hello {name}"); }', { name: 'Tobi' })
+      .should.equal('Hello Tobi: function () { console.log("Hello Tobi"); }');
+  })
+
   it('should utilize language definitions', function(){
     t.es = { 'Hello': 'Hola' };
     t('Hello', 'es').should.equal('Hola');

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,6 @@ describe('t(str)', function(){
 
   it('should replace tokens', function(){
     t('Hello {name}', { name: 'Tobi' }).should.equal('Hello Tobi');
-    t('Hello {name}').should.equal('Hello {name}');
     t('{name} is {age} year(s) old', { name: 'Tobi', age: 2 })
       .should.equal('Tobi is 2 year(s) old');
     t('{name.first} is from {name.last}\'s family.', { name: { first: 'Tobi', last: 'Goldman' } })
@@ -17,6 +16,12 @@ describe('t(str)', function(){
 
   it('should work with falsy values', function () {
     t('"{string}",{number}', {string: '', number: 0}).should.eql('"",0');
+  })
+
+  it('should ignore undefined tokens', function () {
+    t('Hello {name}').should.equal('Hello {name}');
+    t('Hello {name}, this is odd syntax: {...}', { name: 'Tobi' })
+      .should.equal('Hello Tobi, this is odd syntax: {...}');
   })
 
   it('should only tokenize innermost brackets', function() {


### PR DESCRIPTION
`{ greeting: "hey {joe}" }` will now match `joe` instead of `greeting: "hey {joe`.

`function () { code.examples('are now allowed'); }` is now allowed.
